### PR TITLE
chore: bump version to 1.3.1.dev1 and improve tooling

### DIFF
--- a/.github/workflows/uv_publish.yaml
+++ b/.github/workflows/uv_publish.yaml
@@ -1,9 +1,12 @@
 name: uv Publish to PyPI or TestPyPI
 
 on:
+  # Automated triggers
   push:
     tags:
-      - "v*.*.*"
+      - "v*.*.*" # Trigger on standard version tags
+      - "!v*.*.*.dev*" # Ignore development releases
+  # Manual triggers
   workflow_dispatch:
     inputs:
       index:
@@ -18,10 +21,11 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Select environment based on manual input, default to 'pypi' on pushed tags
     environment: ${{ inputs.index || 'pypi' }}
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Crucial for PyPI Trusted Publishing (OIDC)
 
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ Issues = "https://github.com/treeolivetech/pkg-tawala/issues"
 # Changelog = "https://github.com/treeolivetech/pkg-tawala/blob/main/CHANGELOG.md"
 
 [project]
-name = "Tawala"
-version = "1.3.0"
+name = "tawala"
+version = "1.3.1.dev1"
 description = "Build and deploy Django apps with confidence."
 readme = "README.md"
 license = "MIT"

--- a/src/tawala/management/commands/startproject.py
+++ b/src/tawala/management/commands/startproject.py
@@ -157,7 +157,7 @@ class Command(BaseCommand):
             'version = "0.1.0"\n'
             'description = ""\n'
             'readme = "README.md"\n'
-            'requires-python = ">=3.12"\n'
+            'requires-python = ">=3.13"\n'
             f"dependencies = [{dependencies}]\n"
             "\n"
             "[dependency-groups]\n"
@@ -168,11 +168,10 @@ class Command(BaseCommand):
 
     def _get_gitignore_content(self, args: Namespace) -> str:
         """Generate the content for .gitignore based on the provided arguments."""
-        sqlite = f"/db.{DatabaseChoices.SQLITE}3\n" if args.db == DatabaseChoices.SQLITE else ""
+        sqlite = f"\n# SQLite database\n/db.{DatabaseChoices.SQLITE}3\n" if args.db == DatabaseChoices.SQLITE else ""
         return (
             "# Python-generated files\n"
             "__pycache__/\n"
-            "*.py[oc]\n"
             "\n"
             "# Virtual environment\n"
             "/.venv/\n"

--- a/uv.lock
+++ b/uv.lock
@@ -905,7 +905,7 @@ wheels = [
 
 [[package]]
 name = "tawala"
-version = "1.3.0"
+version = "1.3.1.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "christianwhocodes" },


### PR DESCRIPTION
- Bump package version to 1.3.1.dev1 in pyproject.toml
- ci: update uv_publish workflow to add descriptive comments and explicitly ignore development releases (!v*.*.*.dev*) from automatically publishing
- fix(startproject): bump requires-python from >=3.12 to >=3.13 in the generated pyproject.toml to align with the package requirements
- fix(startproject): improve formatting of the generated .gitignore file by adding a SQLite comment and removing redundant entries

Closes #1