### PR TITLE
feat(settings): add db ssl-mode choices and default timezone to UTC

### DIFF
--- a/src/tawala/management/settings/_02_databases.py
+++ b/src/tawala/management/settings/_02_databases.py
@@ -35,7 +35,13 @@ class _DatabaseConf(BaseConf):
     host = ConfField(type=str, env="DB_HOST", toml="db.host", default="")
     port = ConfField(type=str, env="DB_PORT", toml="db.port", default="")
     pool = ConfField(type=bool, env="DB_POOL", toml="db.pool", default=False)
-    ssl_mode = ConfField(type=str, env="DB_SSL_MODE", toml="db.ssl-mode", default="prefer")
+    ssl_mode = ConfField(
+        type=str,
+        choices=["prefer", "require", "disable", "allow", "verify-ca", "verify-full"],
+        env="DB_SSL_MODE",
+        toml="db.ssl-mode",
+        default="prefer",
+    )
 
 
 _DATABASE = _DatabaseConf()

--- a/src/tawala/management/settings/_05_internationalization.py
+++ b/src/tawala/management/settings/_05_internationalization.py
@@ -13,10 +13,10 @@ class _InternationalizationConf(BaseConf):
 
     verbose_name = "05. Internationalization Configuration"
 
-    language_code = ConfField(type=str, env="LANGUAGE_CODE", toml="internationalization.language_code", default="en-us")
-    time_zone = ConfField(type=str, env="TIME_ZONE", toml="internationalization.time_zone", default="Africa/Nairobi")
-    use_i18n = ConfField(type=bool, env="USE_I18N", toml="internationalization.use_i18n", default=True)
-    use_tz = ConfField(type=bool, env="USE_TZ", toml="internationalization.use_tz", default=True)
+    language_code = ConfField(type=str, env="LANGUAGE_CODE", toml="internationalization.language-code", default="en-us")
+    time_zone = ConfField(type=str, env="TIME_ZONE", toml="internationalization.time-zone", default="UTC")
+    use_i18n = ConfField(type=bool, env="USE_I18N", toml="internationalization.use-i18n", default=True)
+    use_tz = ConfField(type=bool, env="USE_TZ", toml="internationalization.use-tz", default=True)
 
 
 _INTERNATIONALIZATION = _InternationalizationConf()


### PR DESCRIPTION
- add explicit supported choices for db.ssl-mode in settings configuration
- expose db.ssl-mode options in generated project README so valid values are clear
- change internationalization.time-zone default from Africa/Nairobi to UTC
- preserve env and TOML overrides
- closes #3